### PR TITLE
Added description query to Pinterest Button url

### DIFF
--- a/react-social.js
+++ b/react-social.js
@@ -348,7 +348,8 @@
     , constructUrl: function () {
       var url = "https://pinterest.com/pin/create/button/?url="
                 + encodeURIComponent(this.props.url) + "&media="
-                + encodeURIComponent(this.props.media);
+                + encodeURIComponent(this.props.media) + "&description="
+                + encodeURIComponent(this.props.message);
       return url;
     }
   });


### PR DESCRIPTION
Added the description query param using the message prop to the Pinterest Button URL as Pinterest seems to expect this now to show a preview
